### PR TITLE
ifdef the ESP8266 specific EEPROM.commit();

### DIFF
--- a/EepromStream.cpp
+++ b/EepromStream.cpp
@@ -45,7 +45,9 @@ int EepromStream::peek(){
 void EepromStream::flush(){
   EEPROM.write(_start-2, _position & 0xFF);
   EEPROM.write(_start-1, (_position >> 8) & 0xFF);
+#ifdef ESP8266
   EEPROM.commit();
+#endif
   _length = _position;
   _position = 0;
 }


### PR DESCRIPTION
Allows to be used with other EEPROM libraries on teensy or arduino.